### PR TITLE
Fix problem that reading windows newline code.

### DIFF
--- a/pyqt4topyqt5.py
+++ b/pyqt4topyqt5.py
@@ -2239,7 +2239,7 @@ class Tools(object):
                 self.last_error = why
                 return None
 
-        return content.split('\n')
+        return content.split(L_SEP)
 
     def get_encoding(self, path):
         lines = []


### PR DESCRIPTION
Thank you for maintaining.

I'm execute pyqt4topyqt5.py on Windows.
Windows's new line code is "\r\n". Also my script has "\r\n".

Thereby output script has "\r\r\n" code...
