### PR TITLE
fix patch file output

### DIFF
--- a/pyqt4topyqt5/__init__.py
+++ b/pyqt4topyqt5/__init__.py
@@ -2739,7 +2739,7 @@ class Main(object):
         cmd = ['diff', '-u', orig, dest]
         with open(diffname, 'a') as outf:
             reply = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-            outf.write(str(reply.communicate()[0]))
+            outf.write(reply.communicate()[0].decode('utf-8'))
 
     def print_(self, msg):
         if self.log:


### PR DESCRIPTION
the patch files generated  with the --diff option, are unusable; because the text is the python string representation of a byte arra:y (b'')

for example, given afile.py:
```
print("hello")
from PyQt4 import QtCore, QtGui
print("hello")
```

```
$ python ./pyqt4topyqt5.py --diff=a.patch afile.py 
$ cat a.patch
b'--- /path/to/dir/afile.py\t2020-07-09 01:02:43.729811526 -0400\n+++ /path/to/dir_PyQt5/afile.py\t2020-07-09 01:17:26.519811234 -0400\n@@ -1,3 +1,3 @@\n print("hello")\n-from PyQt4 import QtCore, QtGui\n+from PyQt5 import QtCore\n print("hello")\n'bi
```