### PR TITLE
fix exception on binary files in the processed tree

### DIFF
--- a/pyqt4topyqt5/__init__.py
+++ b/pyqt4topyqt5/__init__.py
@@ -2536,11 +2536,13 @@ class Main(object):
 
         # check if file is executable and contains a Python shebang
         if mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
-            with open(path, 'r') as inf:
-                line = inf.readline().strip()
-                if line in PYSHEBANG:
-                    return True
-
+            try:
+                with open(path, 'r') as inf:
+                    line = inf.readline().strip()
+                    if line in PYSHEBANG:
+                        return True
+            except UnicodeDecodeError:
+                return False
         return False
 
     def prepare_changes(self, followlinks=False):


### PR DESCRIPTION
previously the pyqt4topyqt5 failed on trees with binary files included in the tree with:

Traceback (most recent call last):
  File ".../lib/python3.10/site-packages/pyqt4topyqt5_pkg/pyqt4topyqt5.py", line 2748, in <module>
    main = Main(sys.argv)
  File ".../lib/python3.10/site-packages/pyqt4topyqt5_pkg/pyqt4topyqt5.py", line 2515, in __init__
    self.prepare_changes(self.followlinks)
  File ".../lib/python3.10/site-packages/pyqt4topyqt5_pkg/pyqt4topyqt5.py", line 2553, in prepare_changes
    self.copy_dir(self.destdir, self.path, followlinks=followlinks)
  File ".../lib/python3.10/site-packages/pyqt4topyqt5_pkg/pyqt4topyqt5.py", line 2613, in copy_dir
    if self.is_python_file(src):
  File ".../lib/python3.10/site-packages/pyqt4topyqt5_pkg/pyqt4topyqt5.py", line 2540, in is_python_file
    line = inf.readline().strip()
  File "/usr/lib64/python3.10/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte